### PR TITLE
♻️ refact(TabMenu): add page state to TabMenu Component

### DIFF
--- a/src/app/playground/mock.tsx
+++ b/src/app/playground/mock.tsx
@@ -1,0 +1,3 @@
+export const mockData = {
+  
+}

--- a/src/app/productList/page.tsx
+++ b/src/app/productList/page.tsx
@@ -1,9 +1,32 @@
+'use client';
 import TabMenu from '@/components/gnb/TabMenu';
+import { SortDropDown } from '@/components/productList/SortDropDown';
+import { sortBy } from '@/components/productList/SortDropDown';
+import { useEffect, useState } from 'react';
+
 
 export default function ProductList() {
+  const [sort, setSort] = useState<sortBy>('newest');
+  const [mainCategory, setMainCategory] = useState<string>('snack');    /* 초기 렌더링시 스낵-스낵을 디폴트 */
+  const [subCategory, setSubCategory] = useState<string>('snack');
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'development') {
+      console.log('정렬 기준:', sort);
+    }
+  }, [sort]);
+
   return (
     <>
-      <TabMenu />
+      <TabMenu mainCategory={mainCategory} subCategory={subCategory} setMain={setMainCategory} setSub={setSubCategory} />
+      <div className='w-full h-[98px] max-lt:h-[68px] px-[120px] max-lt:px-6 flex  items-center justify-end'>
+        <SortDropDown
+          value={sort}
+          setValue={setSort}
+        />
+      </div>
+
+      <div></div>
     </>
   );
 }

--- a/src/components/gnb/TabMenu.tsx
+++ b/src/components/gnb/TabMenu.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { cn } from '@/lib/utils';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 type CategoryType = {
   [key: string]: {
@@ -28,7 +28,7 @@ const categories: CategoryType = {
       { kor: '과즙 음료', eng: 'juice' },
       { kor: '에너지음료', eng: 'energy' },
       { kor: '커피', eng: 'coffee' },
-      { kor: '건감음료', eng: 'health' },
+      { kor: '건강음료', eng: 'health' },
       { kor: '티', eng: 'tea' },
     ],
   },
@@ -59,79 +59,78 @@ const categories: CategoryType = {
   },
 };
 
-export default function TabMenu() {
-  const [activeMain, setActiveMain] = useState<string>('snack');
-  const [activeSub, setActiveSub] = useState<string>('스낵');
-  const [value, setValue] = useState<string>('snack');
+interface IProps {
+  mainCategory: string;
+  subCategory: string;
+  setMain: (value: string) => void;
+  setSub: (value: string) => void;
+}
 
-  const handleValue = (categoryKey: string, itemKor: string) => {
-    const category = categories[categoryKey];
-    const engItem =
-      category.items.find((item) => item.kor === itemKor)?.eng || '';
-    setValue(engItem);
-  };
-
+export default function TabMenu({
+  mainCategory,
+  subCategory,
+  setMain,
+  setSub,
+}: IProps) {
   const ulStyle =
     'flex h-16 text-gray-400 text-2lg font-medium px-[120px] gap-3 items-center border-b-1 border-line-200';
   const buttonStyle =
     'w-full h-full cursor-pointer transition-all duration-300';
 
   useEffect(() => {
-    setActiveSub(categories[activeMain].items[0].kor);
-  }, [activeMain]);
-
-  useEffect(() => {
-    handleValue(activeMain, activeSub);
-  }, [activeSub]);
-
-  useEffect(() => {
     if (process.env.NODE_ENV === 'development') {
-      console.log(value);
+      console.log('상위 카테고리:', mainCategory);
+      console.log('하위 카테고리:', subCategory);
     }
-  }, [value]);
+  }, [subCategory]);
 
   return (
-    <>
-      <nav>
-        <ul className={ulStyle}>
-          {Object.entries(categories).map(([key, category]) => (
-            <li
-              key={key}
-              className='h-full'
+    <nav>
+      {/* 상위 카테고리 */}
+      <ul className={ulStyle}>
+        {Object.entries(categories).map(([key, category]) => (
+          <li
+            key={key}
+            className='h-full'
+          >
+            <button
+              className={cn(
+                buttonStyle,
+                mainCategory === key
+                  ? 'border-b-1 border-b-primary-400 text-primary-400'
+                  : '',
+              )}
+              onClick={() => {
+                setMain(key);
+                setSub(categories[key].items[0].eng); // 상위 카테고리 변경시 하위 카테고리 첫번째를 디폴트
+              }}
             >
-              <button
-                className={cn(
-                  buttonStyle,
-                  `${activeMain === key ? 'border-b-1 border-b-primary-400 text-primary-400' : ''}`,
-                )}
-                onClick={() => setActiveMain(key)}
-              >
-                {category.kor}
-              </button>
-            </li>
-          ))}
-        </ul>
+              {category.kor}
+            </button>
+          </li>
+        ))}
+      </ul>
 
-        <ul className={ulStyle}>
-          {categories[activeMain].items.map((item) => (
-            <li
-              key={item.kor}
-              className='h-full'
+      {/* 하위 카테고리 */}
+      <ul className={ulStyle}>
+        {categories[mainCategory]?.items.map((item) => (
+          <li
+            key={item.kor}
+            className='h-full'
+          >
+            <button
+              className={cn(
+                buttonStyle,
+                'text-lg font-semibold',
+                subCategory === item.eng ? 'text-primary-400' : '',
+              )}
+              onClick={() => setSub(item.eng)}
             >
-              <button
-                className={cn(
-                  buttonStyle,
-                  'text-lg font-semibold',
-                  `${activeSub === item.kor ? 'text-primary-400' : ''}`,
-                )}
-                onClick={() => setActiveSub(item.kor)}
-              >
-                {item.kor}
-              </button>
-            </li>
-          ))}
-        </ul>
-      </nav>
-    </>
+              {item.kor}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </nav>
   );
 }

--- a/src/components/productList/SortDropDown.tsx
+++ b/src/components/productList/SortDropDown.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/Dropdown-Menu';
+import { ChevronDown } from 'lucide-react';
+
+const sortOption: Record<sortBy, string> = {
+  newest: '최신순',
+  sales: '판매순',
+  lowest: '낮은가격순',
+  highest: '높은가격순',
+};
+
+export type sortBy =
+  | 'newest'
+  | 'sales'
+  | 'lowest'
+  | 'highest'; /* 최신순, 판매순, 낮은가격순, 높은가격순 */
+
+interface IProps {
+  value: sortBy;
+  setValue: (value: sortBy) => void;
+}
+
+export function SortDropDown({ value, setValue }: IProps) {
+  const handleSort = (value: sortBy) => {
+    setValue(value);
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        asChild
+        className='flex justify-between items-center gap-4'
+      >
+        <Button
+          variant='outline'
+          className='group text-gray-500 text-md font-normal select-none'
+        >
+          {sortOption[value]}
+          <ChevronDown className='transition-transform duration-200 group-data-[state=open]:rotate-180' />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className='w-56'>
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          <DropdownMenuItem onClick={() => handleSort('newest')}>
+            {sortOption.newest}
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => handleSort('sales')}>
+            {sortOption.sales}
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => handleSort('lowest')}>
+            {sortOption.lowest}
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => handleSort('highest')}>
+            {sortOption.highest}
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}


### PR DESCRIPTION
- 상품 리스트 페이지의 카테고리 상태를 TabMenu 컴포넌트와 동기화하기 위한 리팩토링 작업입니다
  -> TabMenu 기존 상태 제거, productList page의 상,하위 카테고리 상태를 TabMenu에 prop으로 전달