### PR TITLE
🐛 fix:배포에러 해결2

### DIFF
--- a/src/app/cart/[cartId]/page.tsx
+++ b/src/app/cart/[cartId]/page.tsx
@@ -147,13 +147,13 @@ export default function CartsPage() {
               <div className='flex justify-between mb-2'>
                 <span className='text-gray-600'>상품금액</span>
                 <span className='font-semibold'>
-                  {cartData.totalAmount.toLocaleString()}원
+                  {(cartData?.totalAmount ?? 0).toLocaleString()}원
                 </span>
               </div>
               <div className='flex justify-between'>
                 <span className='text-gray-600'>배송비</span>
                 <span className='font-semibold'>
-                  {cartData.shippingFee.toLocaleString()}원
+                  {(cartData?.shippingFee ?? 0).toLocaleString()}원
                 </span>
               </div>
             </div>
@@ -161,7 +161,9 @@ export default function CartsPage() {
             <div className='flex justify-between mb-2'>
               <span className='text-gray-800 font-bold'>총 주문금액</span>
               <span className='text-orange-500 font-bold text-lg'>
-                {(cartData.totalAmount + cartData.shippingFee).toLocaleString()}
+                {(
+                  (cartData?.totalAmount ?? 0) + (cartData?.shippingFee ?? 0)
+                ).toLocaleString()}
                 원
               </span>
             </div>
@@ -169,7 +171,7 @@ export default function CartsPage() {
             <div className='flex justify-between mb-6'>
               <span className='text-gray-600'>남은 예산 금액</span>
               <span className='font-semibold'>
-                {cartData.estimatedRemainingBudget.toLocaleString()}원
+                {(cartData?.estimatedRemainingBudget ?? 0).toLocaleString()}원
               </span>
             </div>
           </div>


### PR DESCRIPTION
🐛 fix:배포에러 해결2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 장바구니 페이지에서 주문 총액, 배송비, 잔여 예산 등의 숫자가 데이터 누락 시에도 올바르게 표시되도록 개선되었습니다. 이번 업데이트는 값이 없을 경우 기본값(0)을 사용하여 예기치 않은 오류를 방지하고, 사용자에게 보다 안정적이고 신뢰할 수 있는 쇼핑 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->