### PR TITLE
feat(productList): ProductListWrapper & 더보기 클릭 이후 스크롤 유지 기능

### DIFF
--- a/src/app/productList/page.tsx
+++ b/src/app/productList/page.tsx
@@ -2,14 +2,14 @@ import { Suspense } from 'react';
 
 import Loading from '@/components/productList/Loading';
 
-import ProductList from './ProductList';
+import ProductListWrapper from '@/components/productList/ProductListWrapper';
 
 export const dynamic = 'force-dynamic';
 
 export default function Page() {
   return (
     <Suspense fallback={<Loading size='L' />}>
-      <ProductList />
+      <ProductListWrapper />
     </Suspense>
   );
 }

--- a/src/components/productList/ProductListWrapper.tsx
+++ b/src/components/productList/ProductListWrapper.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import ProductList from '@/app/productList/ProductList';
+
+export default function ProductListWrapper() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [allowRender, setAllowRender] = useState(false);
+  const isFirst = useRef(true);
+  const page = Number(searchParams.get('page') || '1');
+
+  useEffect(() => {
+    const handleRedirect = async () => {
+      if (isFirst.current && page > 1) {
+        const newParams = new URLSearchParams(searchParams.toString());
+        newParams.set('page', '1');
+        await router.replace(`?${newParams.toString()}`); //비동기 처리로 replace 이후에 렌더링되도록 함
+        return;
+      }
+
+      setAllowRender(true);
+      isFirst.current = false;
+    };
+
+    handleRedirect();
+  }, [page]);
+
+  if (!allowRender) {
+    return null;
+  }
+
+  return <ProductList />;
+}


### PR DESCRIPTION
- ProductListWrapper
  - 기존에 page 2 이상에서 새로고침을 할 경우 리스트 키 중복 에러가 발생했습니다
    이에 대한 처리로 새로고침 시 page = 1로 리다이렉트되도록 하는 기능을 ProductListWrapper에 구현하였습니다

ProductListWrapper와 ClientWrapper는 별개입니다